### PR TITLE
Add bin declaration

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "description": "tf fe tools",
   "main": "tfx.js",
+  "bin": "./bin/tfx",
   "directories": {
     "test": "test"
   },


### PR DESCRIPTION
If your package has executable script, it should be described in `package.json`
